### PR TITLE
Update build script to migrate entirely over to XCFramework

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,12 +10,12 @@ on:
       version:
         description: 'WebP Version Tag'     
         required: true
-        default: 'v1.1.0'
+        default: 'v1.2.0'
 
 jobs:
   build:
     # Run on the latest version of macOS supported
-    runs-on: macos-11.0
+    runs-on: macos-11
 
     steps:
       # Set the version of Xcode to 12.0
@@ -36,9 +36,9 @@ jobs:
           email: ${{ secrets.CI_EMAIL }}
           token: ${{ secrets.API_TOKEN }}
 
-      # Install MacPorts so we can compile C libraries
+      # Install the GNU tools to build from the command line
       - name: Install CL Tools
-        run: pwd && ls && sh cltools.sh
+        run: brew install autoconf automake libtools
 
       # Execute fastlane
       - name: Run Fastlane

--- a/build.sh
+++ b/build.sh
@@ -94,6 +94,8 @@ clone_repo() {
 }
 
 build_ios() {
+      cd ${WEBP_SRC_DIR}
+
   # Query for the SDK version installed
   SDK=$(xcodebuild -showsdks \
     | grep iphoneos | sort | tail -n 1 | awk '{print substr($NF, 9)}'
@@ -111,12 +113,22 @@ build_ios() {
 
   # Build all of the iOS native device slices
   build_common
-  build_slice "armv7" "armv7-apple-ios" "arm-apple-darwin" "iphoneos" "-miphoneos-version-min=9.0"
-  build_slice "armv7s" "armv7s-apple-ios" "arm-apple-darwin" "iphoneos" "-miphoneos-version-min=9.0"
-  build_slice "arm64" "aarch64-apple-ios" "arm-apple-darwin" "iphoneos" "-miphoneos-version-min=9.0"
-  build_slice "x86_64" "x86_64-apple-ios" "x86_64-apple-darwin" "iphonesimulator" "-miphoneos-version-min=9.0"
-  build_slice "i386" "i386-apple-ios" "i386-apple-darwin" "iphonesimulator" "-miphoneos-version-min=9.0"
-  make_frameworks "iOS"
+
+  # iOS Native
+  #build_slice "armv7" "armv7-apple-ios" "arm-apple-darwin" "iphoneos" "-miphoneos-version-min=9.0"
+  #build_slice "armv7s" "armv7s-apple-ios" "arm-apple-darwin" "iphoneos" "-miphoneos-version-min=9.0"
+  #build_slice "arm64" "aarch64-apple-ios" "arm-apple-darwin" "iphoneos" "-miphoneos-version-min=9.0"
+
+  # iOS Simulator
+  #build_slice "x86_64" "x86_64-apple-ios9.0-simulator" "x86_64-apple-darwin" "iphonesimulator" "-miphoneos-version-min=9.0"
+  # build_slice "i386" "i386-apple-ios9.0-simulator" "i386-apple-darwin" "iphonesimulator" "-miphoneos-version-min=9.0"
+  # build_slice "arm64" "arm64-apple-ios9.0-simulator" "aarch64-apple-darwin" "iphonesimulator" "-miphoneos-version-min=9.0"
+
+  # Mac Catalyst
+  build_slice "x86_64" "x86_64-apple-ios13.0-macabi" "x86_64-apple-darwin" "macosx" ""
+  build_slice "arm64" "aarch64-apple-ios-macabi" "arm-apple-darwin" "macosx" ""
+
+  make_xcframeworks "iOS"
 }
 
 build_ios_catalyst() {
@@ -160,8 +172,13 @@ build_tvos() {
   BUILDDIR="$(pwd)/tvosbuild"
 
   build_common
+
+  # tvOS Simulator
+  build_slice "arm64" "arm64-apple-tvos9.0-simulator" "aarch64-apple-darwin" "appletvsimulator" "-mtvos-version-min=9.0"
+  build_slice "x86_64" "x86_64-apple-tvos9.0-simulator" "x86_64-apple-darwin" "appletvsimulator" "-mtvos-version-min=9.0"
+
+  # tvOS Native Devices
   build_slice "arm64" "aarch64-apple-tvos" "arm-apple-darwin" "appletvos" "-mtvos-version-min=9.0"
-  build_slice "x86_64" "x86_64-apple-tvos" "x86_64-apple-darwin" "appletvsimulator" "-mtvos-version-min=9.0"
   make_frameworks "tvOS"
 }
 
@@ -204,10 +221,16 @@ build_watchos() {
   BUILDDIR="$(pwd)/watchosbuild"
 
   build_common
+
+  # watchOS Simulator
+  build_slice "arm64" "arm64-apple-watchos2.0-simulator" "aarch64-apple-darwin" "watchsimulator" "-mwatchos-version-min=2.0"
+  build_slice "x86_64" "x86_64-apple-watchos2.0-simulator" "x86_64-apple-darwin" "watchsimulator" "-mwatchos-version-min=2.0"
+  build_slice "i386" "i386-apple-watchos2.0-simulator" "i386-apple-darwin" "watchsimulator" "-mwatchos-version-min=2.0"
+
+  # watchOS Native Devices
   build_slice "arm64_32" "arm64_32-apple-watchos" "arm-apple-darwin" "watchos" "-mwatchos-version-min=2.0"
   build_slice "armv7k" "armv7k-apple-watchos" "arm-apple-darwin" "watchos" "-mwatchos-version-min=2.0"
-  build_slice "x86_64" "x86_64-apple-watchos" "x86_64-apple-darwin" "watchsimulator" "-mwatchos-version-min=2.0"
-  build_slice "i386" "i386-apple-watchos" "i386-apple-darwin" "watchsimulator" "-mwatchos-version-min=2.0"
+
   make_frameworks "watchOS"
 }
 
@@ -245,8 +268,8 @@ build_slice() {
   HOST=$3
   PLATFORM=$4
   VERSION=$5
-  
-  ROOTDIR="${BUILDDIR}/${PLATFORM}-${ARCH}"
+
+  ROOTDIR="${BUILDDIR}/${TARGET}"
   mkdir -p "${ROOTDIR}"
   
   DEVROOT="${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain"
@@ -561,7 +584,7 @@ case "$COMMAND" in
         ;;
 
     "ios")
-        clone_repo
+        # clone_repo
         build_ios
         exit 0
         ;;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,7 @@ lane :package do |options|
   
   # Build the binaries
   UI.message "Building binaries..."
-  sh "cd .. && sh build.sh build"
+  sh "cd .. && sh build.sh all"
   UI.success "... done!"
 
   # Package up the main bundle

--- a/templates/README.md
+++ b/templates/README.md
@@ -38,48 +38,12 @@ For fast access, the binaries are bundled up and provided in a variety of differ
         <th>Download Packages</th>
     </tr>
     <tr>
-        <td><b>iOS</b><br />(Mac Catalyst)</td>
-        <td>iOS 11.0 and up.<br/>macOS 10.15 and up.</td>
+        <td><strong>iOS<br/>iPadOS</strong></td>
         <td>
-            <ul>
-                <li><code>arm64</code></li>
-                <li><code>x86_64</code> (Mac Catalyst)</li>
-                <li><code>x86_64</code> (Simulator)</li>
-            </ul>
+	        iOS 9.0 and up.<br/>
+	        iPadOS 13.0 and up.<br/>
+	        Mac Catalyst 13.0 and up.
         </td>
-        <td>
-            <ul>
-                <li>
-                    <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-catalyst.zip">
-                        <strong>Download All (ZIP)</strong>
-                    </a>
-                </li>
-                <li>
-                    <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-catalyst-webp.zip">
-                        <code>WebP.xcframework</code>
-                    </a>
-                </li>
-                <li>
-                    <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-catalyst-webpdecoder.zip">
-                        <code>WebPDecoder.xcframework</code>
-                    </a>
-                </li>
-                <li>
-                    <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-catalyst-webpdemux.zip">
-                        <code>WebPDemux.xcframework</code>
-                    </a>
-                </li>
-                <li>
-                    <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-catalyst-webpmux.zip">
-                        <code>WebPMux.xcframework</code>
-                    </a>
-                </li>
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td><strong>iOS</strong></td>
-        <td>iOS 9.0 and up.</td>
         <td>
             <ul>
                 <li><code>arm64</code></li>
@@ -98,22 +62,22 @@ For fast access, the binaries are bundled up and provided in a variety of differ
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-webp.zip">
-                        <code>WebP.framework</code>
+                        <code>WebP.xcframework</code>
                     </a>
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-webpdecoder.zip">
-                        <code>WebPDecoder.framework</code>
+                        <code>WebPDecoder.xcframework</code>
                     </a>
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-webpdemux.zip">
-                        <code>WebPDemux.framework</code>
+                        <code>WebPDemux.xcframework</code>
                     </a>
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-ios-webpmux.zip">
-                        <code>WebPMux.framework</code>
+                        <code>WebPMux.xcframework</code>
                     </a>
                 </li>
             </ul>
@@ -137,22 +101,22 @@ For fast access, the binaries are bundled up and provided in a variety of differ
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-macos-webp.zip">
-                    <code>WebP.framework</code>
+                    <code>WebP.xcframework</code>
                 </a>
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-macos-webpdecoder.zip">
-                    <code>WebPDecoder.framework</code>
+                    <code>WebPDecoder.xcframework</code>
                 </a>
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-macos-webpdemux.zip">
-                    <code>WebPDemux.framework</code>
+                    <code>WebPDemux.xcframework</code>
                 </a>
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-macos-webpmux.zip">
-                    <code>WebPMux.framework</code>
+                    <code>WebPMux.xcframework</code>
                 </a>
             </li>
             </ul>
@@ -176,22 +140,22 @@ For fast access, the binaries are bundled up and provided in a variety of differ
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-tvos-webp.zip">
-                    <code>WebP.framework</code>
+                    <code>WebP.xcframework</code>
                 </a>
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-tvos-webpdecoder.zip">
-                    <code>WebPDecoder.framework</code>
+                    <code>WebPDecoder.xcframework</code>
                 </a>
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-tvos-webpdemux.zip">
-                    <code>WebPDemux.framework</code>
+                    <code>WebPDemux.xcframework</code>
                 </a>
             </li>
             <li>
                 <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-tvos-webpmux.zip">
-                    <code>WebPMux.framework</code>
+                    <code>WebPMux.xcframework</code>
                 </a>
             </li>
             </ul>
@@ -217,22 +181,22 @@ For fast access, the binaries are bundled up and provided in a variety of differ
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-watchos-webp.zip">
-                        <code>WebP.framework</code>
+                        <code>WebP.xcframework</code>
                     </a>
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-watchos-webpdecoder.zip">
-                        <code>WebPDecoder.framework</code>
+                        <code>WebPDecoder.xcframework</code>
                     </a>
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-watchos-webpdemux.zip">
-                        <code>WebPDemux.framework</code>
+                        <code>WebPDemux.xcframework</code>
                     </a>
                 </li>
                 <li>
                     <a href="https://github.com/TimOliver/WebP-Cocoa/releases/download/{tag_version}/libwebp-{tag_version}-framework-watchos-webpmux.zip">
-                        <code>WebPMux.framework</code>
+                        <code>WebPMux.xcframework</code>
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
After discovering that it is indeed possible to have XCFramework files support iOS 9 (but it requires using `lipo` to manually combine the separate libraries into a per-platform fat binary), I went back and reworked the build script to move the lot over to using `xcframework` files now.